### PR TITLE
Fix compatibility with Transmission 4.0.2

### DIFF
--- a/src/transmission.rs
+++ b/src/transmission.rs
@@ -316,8 +316,6 @@ static TORRENT_DETAILS_FIELDS: &[&str] = &[
     "name",
     "eta",
     "sizeWhenDone",
-    "seederCount",
-    "leecherCount",
     "downloadDir",
     "comment",
     "hashString",
@@ -325,7 +323,6 @@ static TORRENT_DETAILS_FIELDS: &[&str] = &[
     "rateUpload",
     "uploadRatio",
     "seedRatioLimit",
-    "priority",
     "doneDate",
     "percentDone",
     "downloadedEver",
@@ -357,10 +354,6 @@ pub struct TorrentDetails {
     pub eta: i64,
     #[serde(rename = "sizeWhenDone")]
     pub size_when_done: u64,
-    #[serde(rename = "seederCount")]
-    pub seeder_count: i64,
-    #[serde(rename = "leecherCount")]
-    pub leecher_count: i64,
     #[serde(deserialize_with = "status_deserializer")]
     pub status: TorrentStatus,
     #[serde(rename = "downloadDir")]
@@ -377,8 +370,6 @@ pub struct TorrentDetails {
     pub upload_ratio: f64,
     #[serde(rename = "seedRatioLimit")]
     pub seed_ratio_limit: u64,
-    #[serde(rename = "priority")]
-    pub priority: u64,
     #[serde(rename = "doneDate")]
     pub done_date: u64,
     #[serde(rename = "percentDone")]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -719,10 +719,6 @@ fn render_details<'a>(details: &'a TorrentDetails, styles: &Styles) -> Table<'a>
             Cell::from(Span::styled(format_size(details.size_when_done as i64), value_style)),
         ]),
         Row::new(vec![
-            Cell::from(Span::styled("Priority", key_style)),
-            Cell::from(Span::styled(format!("{}", details.priority), value_style)),
-        ]),
-        Row::new(vec![
             Cell::from(Span::styled("First tracker:", key_style)),
             Cell::from(Span::styled(details.trackers.first().map_or(String::from(""), |t| format_tracker_url(&t.announce)), value_style)),
         ]),


### PR DESCRIPTION
Hello!

While attempting to run your tui on the latest version of `tranmission-daemon` (`4.0.2 (2a57b17031)`, official Arch Linux package), I've encountered some problems with missing `rpc` response fields and decided to hack my way through them:

1. The `seederCount` field was not present in torrent information:

![image](https://user-images.githubusercontent.com/19196352/232635104-47a8a1ad-ec60-41de-b005-0e2a6b2abac7.png)

2. After removing `seederCount`, the `leecherCount` field was missing:

![image](https://user-images.githubusercontent.com/19196352/232635377-554c6b3a-aec0-4d59-a3ca-d776928af504.png)

3. Then, after removing `leecherCount`, `priority` was missing:

![image](https://user-images.githubusercontent.com/19196352/232635422-85ed60d8-c18b-4594-9af3-1b4c9c056513.png)

After removing the aforementioned fields, the program started working again :smile: 

I verified that the fields are no longer present in the response by:
- reading through [Transmission's RPC spec](https://github.com/transmission/transmission/blob/main/docs/rpc-spec.md#33-torrent-accessor-torrent-get)
- running `transmission-remote --json -t 1 --info` 

I can confirm that `seederCount`, `leecherCount` and `priority` are no longer present in the reponse.