### PR TITLE
Correct cargoSha256 in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,7 @@
               fetchSubmodules = true;
             };*/
 
-            cargoSha256 = "sha256-kMmHp+pjeTN5qD2cjrNr+14b3HJaD84Y8xydkaEJBak=";
+            cargoSha256 = "sha256-zwK5QKZ9DZhHKm131iWDJ3xlZOu5OcaXo+Cp12RptKw=";
 
             nativeBuildInputs = [ pkg-config ];
             buildInputs = [


### PR DESCRIPTION
It's just wrong:
```
error: hash mismatch in fixed-output derivation '/nix/store/kcrs6ajrlbhlsb94b13lilhrj4mkxvqw-transg-tui-0.0.1-vendor.tar.gz.drv':
         specified: sha256-kMmHp+pjeTN5qD2cjrNr+14b3HJaD84Y8xydkaEJBak=
            got:    sha256-zwK5QKZ9DZhHKm131iWDJ3xlZOu5OcaXo+Cp12RptKw=
```
I can successfully consume the flake with this patch 🌞.