### PR TITLE
Replace `cargoSha256` with `cargoHash`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,7 @@
               fetchSubmodules = true;
             };*/
 
-            cargoSha256 = "sha256-zwK5QKZ9DZhHKm131iWDJ3xlZOu5OcaXo+Cp12RptKw=";
+            cargoHash = "sha256-zwK5QKZ9DZhHKm131iWDJ3xlZOu5OcaXo+Cp12RptKw=";
 
             nativeBuildInputs = [ pkg-config ];
             buildInputs = [


### PR DESCRIPTION
Recent versions of nixpkgs emit this warning:
```
evaluation warning: cargoSha256 is deprecated. Please use cargoHash with SRI hash instead
```

Fix it. We were already using the SRI format, so we just have to rename the attr.