### PR TITLE
fix: make TorrentDetails::seed_ratio_limit a f64

### DIFF
--- a/src/transmission.rs
+++ b/src/transmission.rs
@@ -369,7 +369,7 @@ pub struct TorrentDetails {
     #[serde(rename = "uploadRatio")]
     pub upload_ratio: f64,
     #[serde(rename = "seedRatioLimit")]
-    pub seed_ratio_limit: u64,
+    pub seed_ratio_limit: f64,
     #[serde(rename = "doneDate")]
     pub done_date: u64,
     #[serde(rename = "percentDone")]


### PR DESCRIPTION
Fix the following error message when launching the tui:

> Bloody hell!
>
> Communication failed
> invalid type: floating point `2.0`, expected u64

Some recent update with transmission must have changed how seed_ratio_limit is represented/serialized. I didn't check what exactly have changed.